### PR TITLE
security: add missing workflow permissions blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   template-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   template-maintenance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds top-level `permissions: contents: read` to workflows that were missing an explicit permissions declaration.

**Files changed:**
- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`

Without an explicit `permissions:` block, workflows inherit the org/repo default token permissions, which can be `write-all` depending on settings. Explicit `contents: read` follows the principle of least privilege — these workflows only checkout code and run commands; they don't push, create releases, or write to GitHub Pages.

Resolves `actions/missing-workflow-permissions` code scanning alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
